### PR TITLE
Backward quaternary function application.

### DIFF
--- a/Prelude/Application.swift
+++ b/Prelude/Application.swift
@@ -59,3 +59,10 @@ public func <| <T, U, V> (left: (T, U) -> V, right: T) -> U -> V {
 public func <| <T, U, V, W> (left: (T, U, V) -> W, right: T) -> (U, V) -> W {
 	return { left(right, $0, $1) }
 }
+
+/// Backward quaternary function application.
+///
+/// Applies the function on the left to the value on the right, returning a binary function.
+public func <| <T, U, V, W, X> (left: (T, U, V, W) -> X, right: T) -> (U, V, W) -> X {
+	return { left(right, $0, $1, $2) }
+}


### PR DESCRIPTION
`f <| x` for quaternary `f`.