### PR TITLE
Optional conjunction

### DIFF
--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		547B48331A39A7EF00B60CA9 /* FlipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C9A1181A34D606009C6CD3 /* FlipTests.swift */; };
 		D461E3F71A943DA6005E6A15 /* Conjunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D461E3F61A943DA6005E6A15 /* Conjunction.swift */; };
 		D461E3F81A943E26005E6A15 /* Conjunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D461E3F61A943DA6005E6A15 /* Conjunction.swift */; };
+		D461E3FA1A944388005E6A15 /* ConjunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D461E3F91A944388005E6A15 /* ConjunctionTests.swift */; };
+		D461E3FB1A9447A3005E6A15 /* ConjunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D461E3F91A944388005E6A15 /* ConjunctionTests.swift */; };
 		D4BAEF831A2D6091006E25DF /* Compose.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BAEF821A2D6091006E25DF /* Compose.swift */; };
 		D4BAEF851A2D609A006E25DF /* ComposeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BAEF841A2D609A006E25DF /* ComposeTests.swift */; };
 		D4BAF0421A2E79D6006E25DF /* Fix.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BAF0411A2E79D6006E25DF /* Fix.swift */; };
@@ -60,6 +62,7 @@
 		547B480E1A39A78200B60CA9 /* Prelude.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		547B48181A39A78300B60CA9 /* Prelude-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Prelude-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D461E3F61A943DA6005E6A15 /* Conjunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Conjunction.swift; sourceTree = "<group>"; };
+		D461E3F91A944388005E6A15 /* ConjunctionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConjunctionTests.swift; sourceTree = "<group>"; };
 		D4BAEF821A2D6091006E25DF /* Compose.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Compose.swift; sourceTree = "<group>"; };
 		D4BAEF841A2D609A006E25DF /* ComposeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeTests.swift; sourceTree = "<group>"; };
 		D4BAF0411A2E79D6006E25DF /* Fix.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fix.swift; sourceTree = "<group>"; };
@@ -163,6 +166,7 @@
 				D4D33D9419FE8F8C001D051D /* PreludeTests.swift */,
 				D4BC08F41A3385CC007D52F8 /* ApplicationTests.swift */,
 				D4BAEF841A2D609A006E25DF /* ComposeTests.swift */,
+				D461E3F91A944388005E6A15 /* ConjunctionTests.swift */,
 				D4E7A80A1A2D3A740080A4DF /* CurryTests.swift */,
 				D4BAF0431A2E79E5006E25DF /* FixTests.swift */,
 				D4C9A1181A34D606009C6CD3 /* FlipTests.swift */,
@@ -369,6 +373,7 @@
 				547B48331A39A7EF00B60CA9 /* FlipTests.swift in Sources */,
 				547B482F1A39A7EF00B60CA9 /* ApplicationTests.swift in Sources */,
 				547B482E1A39A7EF00B60CA9 /* PreludeTests.swift in Sources */,
+				D461E3FB1A9447A3005E6A15 /* ConjunctionTests.swift in Sources */,
 				547B48301A39A7EF00B60CA9 /* ComposeTests.swift in Sources */,
 				547B48321A39A7EF00B60CA9 /* FixTests.swift in Sources */,
 				547B48311A39A7EF00B60CA9 /* CurryTests.swift in Sources */,
@@ -396,6 +401,7 @@
 				D4C9A1191A34D606009C6CD3 /* FlipTests.swift in Sources */,
 				D4D33D9519FE8F8C001D051D /* PreludeTests.swift in Sources */,
 				D4E7A80B1A2D3A740080A4DF /* CurryTests.swift in Sources */,
+				D461E3FA1A944388005E6A15 /* ConjunctionTests.swift in Sources */,
 				D4BC08F51A3385CC007D52F8 /* ApplicationTests.swift in Sources */,
 				D4BAEF851A2D609A006E25DF /* ComposeTests.swift in Sources */,
 				D4BAF0441A2E79E5006E25DF /* FixTests.swift in Sources */,

--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		547B48311A39A7EF00B60CA9 /* CurryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E7A80A1A2D3A740080A4DF /* CurryTests.swift */; };
 		547B48321A39A7EF00B60CA9 /* FixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BAF0431A2E79E5006E25DF /* FixTests.swift */; };
 		547B48331A39A7EF00B60CA9 /* FlipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C9A1181A34D606009C6CD3 /* FlipTests.swift */; };
+		D461E3F71A943DA6005E6A15 /* Conjunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D461E3F61A943DA6005E6A15 /* Conjunction.swift */; };
+		D461E3F81A943E26005E6A15 /* Conjunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D461E3F61A943DA6005E6A15 /* Conjunction.swift */; };
 		D4BAEF831A2D6091006E25DF /* Compose.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BAEF821A2D6091006E25DF /* Compose.swift */; };
 		D4BAEF851A2D609A006E25DF /* ComposeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BAEF841A2D609A006E25DF /* ComposeTests.swift */; };
 		D4BAF0421A2E79D6006E25DF /* Fix.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BAF0411A2E79D6006E25DF /* Fix.swift */; };
@@ -57,6 +59,7 @@
 /* Begin PBXFileReference section */
 		547B480E1A39A78200B60CA9 /* Prelude.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		547B48181A39A78300B60CA9 /* Prelude-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Prelude-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D461E3F61A943DA6005E6A15 /* Conjunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Conjunction.swift; sourceTree = "<group>"; };
 		D4BAEF821A2D6091006E25DF /* Compose.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Compose.swift; sourceTree = "<group>"; };
 		D4BAEF841A2D609A006E25DF /* ComposeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeTests.swift; sourceTree = "<group>"; };
 		D4BAF0411A2E79D6006E25DF /* Fix.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fix.swift; sourceTree = "<group>"; };
@@ -140,6 +143,7 @@
 				D4E7A8081A2D3A6A0080A4DF /* Curry.swift */,
 				D4BAF0411A2E79D6006E25DF /* Fix.swift */,
 				D4C9A1161A34D5E5009C6CD3 /* Flip.swift */,
+				D461E3F61A943DA6005E6A15 /* Conjunction.swift */,
 				D4D33D8519FE8F8C001D051D /* Supporting Files */,
 			);
 			path = Prelude;
@@ -350,6 +354,7 @@
 			files = (
 				547B48291A39A7BD00B60CA9 /* Application.swift in Sources */,
 				547B482A1A39A7BD00B60CA9 /* Compose.swift in Sources */,
+				D461E3F81A943E26005E6A15 /* Conjunction.swift in Sources */,
 				547B482C1A39A7BD00B60CA9 /* Fix.swift in Sources */,
 				547B48281A39A7BD00B60CA9 /* Prelude.swift in Sources */,
 				547B482D1A39A7BD00B60CA9 /* Flip.swift in Sources */,
@@ -376,6 +381,7 @@
 			files = (
 				D4BC08F31A3385BE007D52F8 /* Application.swift in Sources */,
 				D4D33D9F19FE8FAE001D051D /* Prelude.swift in Sources */,
+				D461E3F71A943DA6005E6A15 /* Conjunction.swift in Sources */,
 				D4BAEF831A2D6091006E25DF /* Compose.swift in Sources */,
 				D4E7A8091A2D3A6A0080A4DF /* Curry.swift in Sources */,
 				D4C9A1171A34D5E5009C6CD3 /* Flip.swift in Sources */,

--- a/Prelude/Conjunction.swift
+++ b/Prelude/Conjunction.swift
@@ -2,6 +2,7 @@
 
 // MARK: - Optional conjunction
 
+/// Returns a tuple of two `Optional` values, or `nil` if either or both are `nil`.
 public func &&& <T, U> (left: T?, right: U?) -> (T, U)? {
 	return left.map { x in right.map { y in (x, y) } } ?? nil
 }

--- a/Prelude/Conjunction.swift
+++ b/Prelude/Conjunction.swift
@@ -1,5 +1,12 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
+// MARK: - Optional conjunction
+
+public func &&& <T, U> (left: T?, right: U?) -> (T, U)? {
+	return left.map { x in right.map { y in (x, y) } } ?? nil
+}
+
+
 // MARK: - Operators
 
 infix operator &&& {

--- a/Prelude/Conjunction.swift
+++ b/Prelude/Conjunction.swift
@@ -10,8 +10,8 @@ public func &&& <T, U> (left: T?, right: U?) -> (T, U)? {
 // MARK: - Operators
 
 infix operator &&& {
-	/// Matches Haskell’s associativity.
-	associativity right
+	/// Same associativity as &&.
+	associativity left
 
 	/// Same precedence as &&.
 	precedence 120

--- a/Prelude/Conjunction.swift
+++ b/Prelude/Conjunction.swift
@@ -3,8 +3,11 @@
 // MARK: - Optional conjunction
 
 /// Returns a tuple of two `Optional` values, or `nil` if either or both are `nil`.
-public func &&& <T, U> (left: T?, right: U?) -> (T, U)? {
-	return left.map { x in right.map { y in (x, y) } } ?? nil
+public func &&& <T, U> (left: T?, @autoclosure right: () -> U?) -> (T, U)? {
+	if let x = left, let y = right() {
+		return (x, y)
+	}
+	return nil
 }
 
 

--- a/Prelude/Conjunction.swift
+++ b/Prelude/Conjunction.swift
@@ -1,0 +1,11 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+// MARK: - Operators
+
+infix operator &&& {
+	/// Matches Haskell’s associativity.
+	associativity right
+
+	/// Same precedence as &&.
+	precedence 120
+}

--- a/PreludeTests/ConjunctionTests.swift
+++ b/PreludeTests/ConjunctionTests.swift
@@ -1,0 +1,31 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+final class ConjunctionTests: XCTestCase {
+	func testPairsNonNilOperands() {
+		let left: Int? = 0
+		let right: String? = ""
+		let and = left &&& right
+		XCTAssert(and?.0 == 0)
+		XCTAssert(and?.1 == "")
+	}
+
+	func testDropsBothOperandsIfEitherIsNil() {
+		XCTAssert(((nil as Int?) &&& 1) == nil)
+		XCTAssert((1 &&& (nil as Int?)) == nil)
+		XCTAssert(((nil as Int?) &&& (nil as Int?)) == nil)
+	}
+
+	func testShortCircuits() {
+		var effects = 0
+		let left: Int? = nil
+		let right = { ++effects }
+		XCTAssert((left &&& right()).map(const(true)) == nil)
+		XCTAssertEqual(effects, 0)
+	}
+}
+
+
+// MARK: - Imports
+
+import Prelude
+import XCTest

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Notably, this framework does not provide any new types, or any functions which o
 	- [`|>` and `<|`](#-and--1)
 	- [`curry`](#curry)
 	- [`flip`](#flip)
+	- [`&&&`](#-)
 - [Documentation](#documentation)
 - [Integration](#integration)
 
@@ -123,6 +124,16 @@ Faux operator sectioning using `<|` might be a little surprising using non-commu
 map([1, 2, 3], (-) <| 1) // => [0, -1, -2]
 map([1, 2, 3], flip(-) <| 1) // => [0, 1, 2]
 ```
+
+
+## `&&&`
+
+`Optional` has a `map` method which is just what you need when you want to apply a function to a value if non-`nil`, or return `nil` otherwise. When you have two `Optional` values, you can use `&&&` to combine them:
+
+```swift
+let (x: Int?, y: Int?) = (2, 2)
+(x &&& y).map(+) // => .Some(4)
+``` 
 
 
 # Documentation


### PR DESCRIPTION
Conjunction of `Optional<T>` with the `&&&` operator, analogous with fanout over Haskell’s `Arrow`s.

```swift
(x &&& y) // == (x, y), iff x and y are non-nil, nil otherwise
```

This operator is the subject of a [blog post I wrote](http://intersections.tumblr.com/post/111240204394/the-sum-is-more-than-the-hole-of-its-parts-while), with one minor adjustment: the version herein is short-circuiting, a la `&&`.