### PR TITLE
countElements changed to count Swift 1.2

### DIFF
--- a/Prelude/Application.swift
+++ b/Prelude/Application.swift
@@ -27,7 +27,7 @@ infix operator <| {
 ///
 /// This is a useful way of clarifying the flow of data through a series of functions. For example, you can use this to count the base-10 digits of an integer:
 ///
-///		let digits = 100 |> toString |> countElements // => 3
+///		let digits = 100 |> toString |> count // => 3
 public func |> <T, U> (left: T, right: T -> U) -> U {
 	return right(left)
 }

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The forward and backward application operators (`|>` and `<|` respectively) appl
 This can sometimes make code more readable. This is particularly the case for the forward application operator. `x |> f` is equivalent to `f(x)`, but it reads in the direction that the data flows. The benefit is more obvious with longer function names:
 
 ```swift
-100 |> toString |> countElements // => 3
+100 |> toString |> count // => 3
 // this is equivalent to
 countElements(toString(100))
 ```


### PR DESCRIPTION
The Swift Library changed CountElements to count in Swift 1.2
These documentation changes were missed as part of 
https://github.com/regnerjr/Prelude/commit/407ae4b40bff8d666047df8282cfc69af5b3a564