### PR TITLE
Forward application variant for piping through `T -> ()` functions.

### DIFF
--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 				D4D33D8319FE8F8C001D051D /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		D4D33D8319FE8F8C001D051D /* Products */ = {
 			isa = PBXGroup;

--- a/Prelude/Application.swift
+++ b/Prelude/Application.swift
@@ -33,6 +33,16 @@ public func |> <T, U> (left: T, right: T -> U) -> U {
 }
 
 
+/// Applies the function on the right to the value on the left, but for functions that use the value for side effects instead of transforming it.
+///
+/// This can be a nice way to strap side effects to an expression without having to drop into an imperative style, such as adding configuration to an objects initialization:
+///
+///		lazy var formatter = NSDateFormatter() |> { $0.timeStyle = .FullStyle }
+public func |> <T> (left: T, right: T -> ()) -> T {
+	right(left)
+	return left
+}
+
 // MARK: Backward function application.
 
 /// Backward function application.

--- a/PreludeTests/ApplicationTests.swift
+++ b/PreludeTests/ApplicationTests.swift
@@ -11,6 +11,11 @@ final class ApplicationTests: XCTestCase {
 		XCTAssertEqual(digits, 3)
 	}
 
+	func testUnpureForwardUnaryFunctionApplication() {
+		let formatter = NSDateFormatter() |> { $0.timeStyle = .FullStyle }
+		XCTAssertEqual(formatter.timeStyle, NSDateFormatterStyle.FullStyle)
+	}
+
 	func testForwardBinaryFunctionApplication() {
 		XCTAssertEqual((1, 2) |> (+), 3)
 	}


### PR DESCRIPTION
This adds a variant of the forward application operator for `T -> ()` functions, allowing you to strap side effects to an expression instead of having to drop into an imperative style. While this definitely has some 🙊 factor (and isn't technically forward application?), it really nicely handles a somewhat common desire when dealing with Cocoa's objectiveyness: expressing instances that have a few customized properties as a single expression.

For example, check out how great declaring lazy properties can be:

``` Swift
lazy var formatter = NSDateFormatter() |> {
    $0.dateFormat = "HH:mm"
    $0.timeZone = NSTimeZone(abbreviation: "GMT")
}
```

Or how about inlining customized objects as parameters: 

``` Swift
let tauDay = calendar.dateFromComponents(NSDateComponents() |> {
    $0.month = 6
    $0.day = 28
    $0.year = 2031
})
```

It's also useful for stuff outside of object setup (though this strikes me as a practice that could get messy fast). Here's adding logging to an expression that's being returned, without having to change `return e` into `let result = e; log(result); return result`... or remember how to do this with Xcode breakpoints:

``` Swift
return someExpression |> { logDebug($0) }
```

Things I'm not sure about:
- That this is even a good idea. I really like it and have used it a decent amount already without issue, but part of me keeps thinking that this is the kind of thing that might be either terrible in ways that I'm not experienced enough to notice, or not providing enough of a marginal improvement to justify the overhead.
- That it should reuse the operator. This seems so similar to the existing pipe forward, but is it too easy to write a closure that accidentally returns `Void` instead of `T` or `T` instead of `Void` and get unintended behavior? Using something slightly different (`|>>` or `||>` maybe?) would let the compiler help us out.
- That Prelude is the right place for this. To this outside observer Prelude looks like a good home, and it mostly fits the goals stated in the README (except for authorship), but it also feels slightly out of place as the only impure function in the framework.

So basically, everything(?).

Thoughts?

(Also, totes apologies if just dropping into your project and hollering "Hey, what do you think of this?" with a slightly long rambly pr is a faux pas... or just rude)
