### PR TITLE
Adds podspec

### DIFF
--- a/Prelude.podspec
+++ b/Prelude.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |spec|
+  spec.name             = 'Prelude'
+  spec.version          = '1.5.0'
+  spec.license          = { :type => 'MIT', :file => 'LICENSE' }
+  spec.homepage         = 'https://github.com/robrix/Prelude'
+  spec.authors          = { 'Rob Rix' => 'rob.rix@github.com' }
+  spec.summary          = 'Swift µframework of simple functional programming tools'
+  spec.source           = { :git => 'https://github.com/robrix/Prelude.git', :tag => spec.version.to_s }
+  spec.source_files     = 'Prelude/*.swift'
+  spec.requires_arc     = true
+  spec.ios.deployment_target = "8.0"
+  spec.osx.deployment_target = "10.9"
+end


### PR DESCRIPTION
This adds a pod spec to the repository for version 1.5.0.

This also allows to use `Prelude` as
```
pod 'Prelude', :git => 'https://github.com/robrix/Prelude.git'
```
