### PR TITLE
for Swift3 (appendix)

### DIFF
--- a/Prelude/Curry.swift
+++ b/Prelude/Curry.swift
@@ -3,17 +3,17 @@
 // MARK: - Currying
 
 /// Curries a binary function `f`, producing a function which can be partially applied.
-public func curry<T, U, V>(f: @escaping (T, U) -> V) -> (T) -> (U) -> V {
+public func curry<T, U, V>(_ f: @escaping (T, U) -> V) -> (T) -> (U) -> V {
 	return { x in { f(x, $0) } }
 }
 
 /// Curries a ternary function `f`, producing a function which can be partially applied.
-public func curry<T, U, V, W>(f: @escaping (T, U, V) -> W) -> (T) -> (U) -> (V) -> W {
+public func curry<T, U, V, W>(_ f: @escaping (T, U, V) -> W) -> (T) -> (U) -> (V) -> W {
 	return { x in curry { f(x, $0, $1) } }
 }
 
 /// Curries a quaternary function, `f`, producing a function which can be partially applied.
-public func curry<T, U, V, W, X>(f: @escaping (T, U, V, W) -> X) -> (T) -> (U) -> (V) -> (W) -> X {
+public func curry<T, U, V, W, X>(_ f: @escaping (T, U, V, W) -> X) -> (T) -> (U) -> (V) -> (W) -> X {
 	return { x in curry { f(x, $0, $1, $2) } }
 }
 
@@ -21,16 +21,16 @@ public func curry<T, U, V, W, X>(f: @escaping (T, U, V, W) -> X) -> (T) -> (U) -
 // MARK: - Uncurrying
 
 /// Uncurries a curried binary function `f`, producing a function which can be applied to a tuple.
-public func uncurry<T, U, V>(f: @escaping (T) -> (U) -> V) -> (T, U) -> V {
+public func uncurry<T, U, V>(_ f: @escaping (T) -> (U) -> V) -> (T, U) -> V {
 	return { f($0)($1) }
 }
 
 /// Uncurries a curried ternary function `f`, producing a function which can be applied to a tuple.
-public func uncurry<T, U, V, W>(f: @escaping (T) -> (U) -> (V) -> W) -> (T, U, V) -> W {
+public func uncurry<T, U, V, W>(_ f: @escaping (T) -> (U) -> (V) -> W) -> (T, U, V) -> W {
 	return { f($0)($1)($2) }
 }
 
 /// Uncurries a curried quaternary function `f`, producing a function which can be applied to a tuple.
-public func uncurry<T, U, V, W, X>(f: @escaping (T) -> (U) -> (V) -> (W) -> X) -> (T, U, V, W) -> X {
+public func uncurry<T, U, V, W, X>(_ f: @escaping (T) -> (U) -> (V) -> (W) -> X) -> (T, U, V, W) -> X {
 	return { f($0)($1)($2)($3) }
 }

--- a/Prelude/Fix.swift
+++ b/Prelude/Fix.swift
@@ -7,6 +7,6 @@
 /// \param f  - A function which takes a parameter function, and returns a result function. The result function may recur by calling the parameter function.
 ///
 /// \return  A recursive function.
-public func fix<T, U>(_ f: @escaping ((T) -> U) -> (T) -> U) -> (T) -> U {
+public func fix<T, U>(_ f: @escaping (@escaping (T) -> U) -> (T) -> U) -> (T) -> U {
 	return { f(fix(f))($0) }
 }

--- a/Prelude/Flip.swift
+++ b/Prelude/Flip.swift
@@ -3,20 +3,20 @@
 /// Returns a binary function which calls `f` with its arguments reversed.
 ///
 /// I.e. `flip(f)(x, y)` is equivalent to `f(y, x)`.
-public func flip<T, U, V>(f: @escaping (T, U) -> V) -> (U, T) -> V {
+public func flip<T, U, V>(_ f: @escaping (T, U) -> V) -> (U, T) -> V {
 	return { f($1, $0) }
 }
 
 /// Returns a ternary function which calls `f` with its arguments reversed.
 ///
 /// I.e. `flip(f)(x, y, z)` is equivalent to `f(z, y, x)`.
-public func flip<T, U, V, W>(f: @escaping (T, U, V) -> W) -> (V, U, T) -> W {
+public func flip<T, U, V, W>(_ f: @escaping (T, U, V) -> W) -> (V, U, T) -> W {
 	return { f($2, $1, $0) }
 }
 
 /// Returns a quaternary function which calls `f` with its arguments reversed.
 ///
 /// I.e. `flip(f)(w, x, y, z)` is equivalent to `f(z, y, x, w)`.
-public func flip<T, U, V, W, X>(f: @escaping (T, U, V, W) -> X) -> (W, V, U, T) -> X {
+public func flip<T, U, V, W, X>(_ f: @escaping (T, U, V, W) -> X) -> (W, V, U, T) -> X {
 	return { f($3, $2, $1, $0) }
 }

--- a/Prelude/Optional.swift
+++ b/Prelude/Optional.swift
@@ -3,7 +3,7 @@
 // MARK: - Unit
 
 /// Returns its argument as an `Optional<T>`.
-public func unit<T>(x: T) -> T? {
+public func unit<T>(_ x: T) -> T? {
 	return x
 }
 

--- a/Prelude/Prelude.swift
+++ b/Prelude/Prelude.swift
@@ -1,18 +1,18 @@
 //  Copyright (c) 2014 Rob Rix. All rights reserved.
 
 /// The identity function; returns its argument.
-public func id<T>(x: T) -> T {
+public func id<T>(_ x: T) -> T {
 	return x
 }
 
 
 /// Returns a function which ignores its argument and returns `x` instead.
-public func const<T, U>(x: T) -> (U) -> T {
+public func const<T, U>(_ x: T) -> (U) -> T {
 	return { _ in x }
 }
 
 
 /// Returns a pair with its fields in the opposite order.
-public func swap<A, B>(a: A, b: B) -> (B, A) {
+public func swap<A, B>(_ a: A, _ b: B) -> (B, A) {
 	return (b, a)
 }

--- a/Prelude/Tuple.swift
+++ b/Prelude/Tuple.swift
@@ -2,10 +2,10 @@
 
 // MARK: - Components extraction
 
-public func first<T, U>(tuple: (T, U)) -> T {
+public func first<T, U>(_ tuple: (T, U)) -> T {
     return tuple.0
 }
 
-public func second<T, U>(tuple: (T, U)) -> U {
+public func second<T, U>(_ tuple: (T, U)) -> U {
     return tuple.1
 }

--- a/PreludeTests/ApplicationTests.swift
+++ b/PreludeTests/ApplicationTests.swift
@@ -55,24 +55,24 @@ final class ApplicationTests: XCTestCase {
 	}
 
 	func testBackwardPartialTernaryFunctionApplication() {
-		let sum: [Int] -> Int = flip(reduce) <| (+) <| 0
+		let sum: ([Int]) -> Int = flip(reduce) <| (+) <| 0
 		XCTAssertEqual(sum([1, 2, 3]), 6)
 	}
 }
 
 
 func toString<T>(x: T) -> String {
-	return String(x)
+	return String(describing: x)
 }
 
 func count(string: String) -> Int {
 	return string.characters.count
 }
 
-func map<S: SequenceType, T>(sequence: S, _ transform: S.Generator.Element -> T) -> [T] {
+func map<S: Sequence, T>(sequence: S, _ transform: (S.Iterator.Element) -> T) -> [T] {
 	return sequence.map(transform)
 }
 
-func reduce<S: SequenceType, T>(sequence: S, initial: T, @noescape combine: (T, S.Generator.Element) -> T) -> T {
-	return sequence.reduce(initial, combine: combine)
+func reduce<S: Sequence, T>(sequence: S, initial: T, combine: (T, S.Iterator.Element) -> T) -> T {
+	return sequence.reduce(initial, combine)
 }

--- a/PreludeTests/ComposeTests.swift
+++ b/PreludeTests/ComposeTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class ComposeTests: XCTestCase {
 	func testRightToLeftCompositionOfUnaryOnUnary() {
-		let composed: [Int] -> Int = (count <<< toString)
+		let composed: ([Int]) -> Int = (count <<< toString)
 		XCTAssertEqual(composed([4]), 3)
 	}
 
@@ -20,7 +20,7 @@ final class ComposeTests: XCTestCase {
 	}
 
 	func testLeftToRightCompositionOfUnaryOnUnary() {
-		let composed: [Int] -> Int = (toString >>> count)
+		let composed: ([Int]) -> Int = (toString >>> count)
 		XCTAssertEqual(composed([4]), 3)
 	}
 

--- a/PreludeTests/ConjunctionTests.swift
+++ b/PreludeTests/ConjunctionTests.swift
@@ -23,7 +23,7 @@ final class ConjunctionTests: XCTestCase {
 	func testShortCircuits() {
 		var effects = 0
 		let left: Int? = nil
-		let right = { ++effects }
+		let right = { effects += 1 }
 		XCTAssert((left &&& right()).map(const(true)) == nil)
 		XCTAssertEqual(effects, 0)
 	}

--- a/PreludeTests/CurryTests.swift
+++ b/PreludeTests/CurryTests.swift
@@ -7,7 +7,7 @@ final class CurryTests: XCTestCase {
 	// MARK: - Currying
 
 	func testBinaryCurrying() {
-		let f: Int -> Int -> Bool = curry(==)
+		let f: (Int) -> (Int) -> Bool = curry(==)
 		XCTAssertTrue(f(0)(0))
 		XCTAssertFalse(f(1)(0))
 		XCTAssertTrue(f(1)(1))
@@ -15,7 +15,7 @@ final class CurryTests: XCTestCase {
 	}
 
 	func testTernaryCurrying() {
-		let f: [Int] -> Int -> ((Int, Int) -> Int) -> Int = curry(reduce)
+		let f: ([Int]) -> (Int) -> ((Int, Int) -> Int) -> Int = curry(reduce)
 		XCTAssertEqual(f([1, 2, 3])(0)(+), 6)
 	}
 
@@ -23,7 +23,7 @@ final class CurryTests: XCTestCase {
 	// MARK: - Uncurrying
 
 	func testBinaryUncurrying() {
-		let f: Int -> Int -> Bool = curry(==)
+		let f: (Int) -> (Int) -> Bool = curry(==)
 		let g = uncurry(f)
 		XCTAssertTrue(g(0, 0))
 		XCTAssertFalse(g(1, 0))
@@ -34,7 +34,7 @@ final class CurryTests: XCTestCase {
 	func testTernaryUncurrying() {
 		typealias ArgumentsTuple = ([Int], Int, (Int, Int) -> Int)
 		let arguments: ArgumentsTuple = ([1, 2, 3], 0, +)
-		let f: ArgumentsTuple -> Int = uncurry(curry(reduce))
-		XCTAssertEqual((reduce as ArgumentsTuple -> Int)(arguments), f(arguments))
+		let f: (ArgumentsTuple) -> Int = uncurry(curry(reduce))
+		XCTAssertEqual((reduce as (ArgumentsTuple) -> Int)(arguments), f(arguments))
 	}
 }

--- a/PreludeTests/FixTests.swift
+++ b/PreludeTests/FixTests.swift
@@ -17,7 +17,7 @@ final class FixTests: XCTestCase {
 			let value: Int
 			let next: () -> Fibonacci
 		}
-		let fibonacci: (Int, Int) -> Fibonacci = fix { recur in
+		let fibonacci: (Int, Int) -> Fibonacci = fix { (recur: @escaping (Int, Int) -> Fibonacci) in
 			{ x, y in Fibonacci(value: x + y, next: { recur(y, x + y) }) }
 		}
 		XCTAssertEqual(fibonacci(0, 1).value, 1)

--- a/PreludeTests/PreludeTests.swift
+++ b/PreludeTests/PreludeTests.swift
@@ -13,6 +13,6 @@ final class PreludeTests: XCTestCase {
 	}
 
 	func testSwap() {
-		XCTAssertEqual("hello".characters.enumerate().map(swap).count, 5)
+		XCTAssertEqual("hello".characters.enumerated().map(swap).count, 5)
 	}
 }


### PR DESCRIPTION
#50 is not enough to support Swift3.

- Omit the argument name
- Modification of some tests
- Add `@escaping` to the inside of `fix`

Please review 🙇 