### PR TITLE
cleanup / #43 | Deprecated `unit`

### DIFF
--- a/Prelude/Optional.swift
+++ b/Prelude/Optional.swift
@@ -3,6 +3,7 @@
 // MARK: - Unit
 
 /// Returns its argument as an `Optional<T>`.
+@available(*, deprecated, message: "Use Optional.Some")
 public func unit<T>(_ x: T) -> T? {
 	return x
 }

--- a/PreludeTests/ConjunctionTests.swift
+++ b/PreludeTests/ConjunctionTests.swift
@@ -1,11 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 final class ConjunctionTests: XCTestCase {
-	func testUnitComposition() {
-		let (a, b): (Int?, Int) = (2, 2)
-		XCTAssertEqual((a &&& unit(b)).map(+) ?? 0, 4)
-	}
-
 	func testPairsNonNilOperands() {
 		let left: Int? = 0
 		let right: String? = ""

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Notably, this framework does not provide any new types, or any functions which o
 	- [`curry`](#curry)
 	- [`flip`](#flip)
 	- [`&&&`](#-)
-	- [`unit`](#unit)
 	- [`swap`](#swap)
 	- [`first` and `second`](#first-and-second)
 - [Documentation](#documentation)
@@ -136,16 +135,6 @@ map([1, 2, 3], flip(-) <| 1) // => [0, 1, 2]
 ```swift
 let (x: Int?, y: Int?) = (2, 2)
 (x &&& y).map(+) // => .Some(4)
-```
-
-
-## `unit`
-
-Sometimes you have a function which produces `T`, but you need one which produces `Optional<T>`. `unit` returns its argument wrapped in an `Optional`, so you can compose with it:
-
-```swift
-let (x: Int?, y: Int) = (2, 2)
-(x &&& unit(y)).map(+) // => .Some(4)
 ```
 
 


### PR DESCRIPTION
As suggested in #43 `unit` deprecated in honor of `Optional.Some`. Documentation removed. Unit-test removed, to avoid deprecation warning during compilation. I believe it is legit, as there are no guarantees anymore on the workability of deprecated functionality, as well as no plans to support it in future. 
`unit` should be removed completely in the future major release.