### PR TITLE
Backward pipe operator has got right associativity.

### DIFF
--- a/Prelude.podspec
+++ b/Prelude.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Prelude'
-  spec.version          = '1.6.0'
+  spec.version          = '1.7.0'
   spec.license          = { :type => 'MIT', :file => 'LICENSE' }
   spec.homepage         = 'https://github.com/robrix/Prelude'
   spec.authors          = { 'Rob Rix' => 'rob.rix@github.com' }

--- a/Prelude.podspec
+++ b/Prelude.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Prelude'
-  spec.version          = '1.7.0'
+  spec.version          = '3.0.0'
   spec.license          = { :type => 'MIT', :file => 'LICENSE' }
   spec.homepage         = 'https://github.com/robrix/Prelude'
   spec.authors          = { 'Rob Rix' => 'rob.rix@github.com' }

--- a/Prelude/Application.swift
+++ b/Prelude/Application.swift
@@ -2,16 +2,20 @@
 
 // MARK: Operators
 
-precedencegroup Application {
-	/// Associates to the left so that pipelines behave as expected.
+precedencegroup ForwardApplication {
+	/// Associates to the left so that pipeline behaves as expected.
 	associativity: left
-	
-	/// Higher precedence than assignment.
 	higherThan: AssignmentPrecedence
 }
 
-infix operator |> : Application
-infix operator <| : Application
+precedencegroup BackwardApplication {
+	/// Associates to the right as `$` in Haskell.
+	associativity: right
+	higherThan: AssignmentPrecedence
+}
+
+infix operator |> : ForwardApplication
+infix operator <| : BackwardApplication
 
 
 // MARK: Forward function application

--- a/Prelude/Optional.swift
+++ b/Prelude/Optional.swift
@@ -1,14 +1,5 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-// MARK: - Unit
-
-/// Returns its argument as an `Optional<T>`.
-@available(*, deprecated, message: "Use Optional.Some")
-public func unit<T>(_ x: T) -> T? {
-	return x
-}
-
-
 // MARK: - Optional conjunction
 
 /// Returns a tuple of two `Optional` values, or `nil` if either or both are `nil`.

--- a/PreludeTests/ApplicationTests.swift
+++ b/PreludeTests/ApplicationTests.swift
@@ -4,6 +4,7 @@ import Prelude
 import XCTest
 
 final class ApplicationTests: XCTestCase {
+
 	// MARK: Forward function application
 
 	func testForwardUnaryFunctionApplication() {
@@ -26,11 +27,10 @@ final class ApplicationTests: XCTestCase {
 		XCTAssertEqual(digits, 3)
 	}
 
-
 	// MARK: Backward function application
 
 	func testBackwardUnaryFunctionApplication() {
-		let digits = count <| (toString <| 100)
+		let digits = count <| toString <| 100
 		XCTAssertEqual(digits, 3)
 	}
 
@@ -39,23 +39,23 @@ final class ApplicationTests: XCTestCase {
 	}
 
 	func testBackwardPipelineWithMixedArity() {
-		let digits = count <| (toString <| ((+) <| (75, 25)))
+		let digits = count <| toString <| (+) <| (75, 25)
 		XCTAssertEqual(digits, 3)
 	}
 
 	func testBackwardFunctionApplicationWithAssignment() {
 		var digits = 0
-		digits += count <| (toString <| 100)
+		digits += count <| toString <| 100
 		XCTAssertEqual(digits, 3)
 	}
 
 	func testBackwardPartialBinaryFunctionApplication() {
-		let strings = flip(map) <| toString <| [1, 2, 3]
+		let strings = (flip(map) <| toString) <| [1, 2, 3]
 		XCTAssertEqual(strings, ["1", "2", "3"])
 	}
 
 	func testBackwardPartialTernaryFunctionApplication() {
-		let sum: ([Int]) -> Int = flip(reduce) <| (+) <| 0
+		let sum: ([Int]) -> Int = (flip(reduce) <| (+)) <| 0
 		XCTAssertEqual(sum([1, 2, 3]), 6)
 	}
 }


### PR DESCRIPTION
Solves issue #55 by changing the backward pipe `<|` operator associativity from left to right.

Version changed from 1.6.0 to 1.7.0 in podspec (minor update). Should we make a major update instead?